### PR TITLE
API Server path update to Kubernetes v1.8

### DIFF
--- a/demos/monitoring/custom-metrics.yaml
+++ b/demos/monitoring/custom-metrics.yaml
@@ -160,7 +160,7 @@ metadata:
   name: custom-metrics-server-resources
 rules:
 - apiGroups:
-  - custom-metrics.metrics.k8s.io
+  - custom.metrics.metrics.k8s.io
   resources: ["*"]
   verbs: ["*"]
 ---


### PR DESCRIPTION
Following the decision in [here](https://github.com/kubernetes/kubernetes/pull/51653).
